### PR TITLE
Adding new features for legend property

### DIFF
--- a/alphaplot/src/2Dplot/Axis2D.cpp
+++ b/alphaplot/src/2Dplot/Axis2D.cpp
@@ -400,7 +400,6 @@ void Axis2D::settickertext(Column *col, int from, int to) {
     textticker->addTick(i, Utilities::splitstring(col->textAt(row)));
     tickertext_->append(col->textAt(row));
   }
-  setticklabelrotation_axis(45);
 }
 
 void Axis2D::save(XmlStreamWriter *xmlwriter) {
@@ -988,7 +987,6 @@ bool Axis2D::load(XmlStreamReader *xmlreader) {
     for (int i = 0; i < tickertext_->size(); i++) {
       textticker->addTick(i, Utilities::splitstring(tickertext_->at(i)));
     }
-    setticklabelrotation_axis(45);
   }
 
   return !xmlreader->hasError();

--- a/alphaplot/src/2Dplot/AxisRect2D.cpp
+++ b/alphaplot/src/2Dplot/AxisRect2D.cpp
@@ -1094,6 +1094,7 @@ bool AxisRect2D::loadLineSpecialChannel2D(XmlStreamReader *xmlreader,
   Axis2D *xaxis1 = nullptr;
   Axis2D *yaxis1 = nullptr;
   AxisRect2D::LineScatterSpecialType ltype1;
+  bool legendvisible1 = true;
   QString legend1;
   Table *table1 = nullptr;
   Column *xcolumn1 = nullptr;
@@ -1114,6 +1115,7 @@ bool AxisRect2D::loadLineSpecialChannel2D(XmlStreamReader *xmlreader,
   Axis2D *xaxis2 = nullptr;
   Axis2D *yaxis2 = nullptr;
   AxisRect2D::LineScatterSpecialType ltype2;
+  bool legendvisible2 = true;
   QString legend2;
   Table *table2 = nullptr;
   Column *xcolumn2 = nullptr;
@@ -1159,11 +1161,14 @@ bool AxisRect2D::loadLineSpecialChannel2D(XmlStreamReader *xmlreader,
               tr("LineSpecialChannel2D line type not found"));
 
         // legend
+        legendvisible1 = xmlreader->readAttributeBool("legendvisible", &ok);
+        if (!ok)
+          xmlreader->raiseWarning(
+              tr("LineSpecialChannel2D legend visible property setting error"));
         legend1 = xmlreader->readAttributeString("legend", &ok);
         if (!ok)
           xmlreader->raiseWarning(
               tr("LineSpecialChannel2D legendtext not found"));
-
         QString tablename = xmlreader->readAttributeString("table", &ok);
         if (ok) {
           table1 = getTableByName(tabs, tablename);
@@ -1368,11 +1373,14 @@ bool AxisRect2D::loadLineSpecialChannel2D(XmlStreamReader *xmlreader,
               tr("LineSpecialChannel2D line type not found"));
 
         // legend
+        legendvisible2 = xmlreader->readAttributeBool("legendvisible", &ok);
+        if (!ok)
+          xmlreader->raiseWarning(
+              tr("LineSpecialChannel2D legend visible property setting error"));
         legend2 = xmlreader->readAttributeString("legend", &ok);
         if (!ok)
           xmlreader->raiseWarning(
               tr("LineSpecialChannel2D legendtext not found"));
-
         QString tablename = xmlreader->readAttributeString("table", &ok);
         if (ok) {
           table2 = getTableByName(tabs, tablename);
@@ -1560,6 +1568,7 @@ bool AxisRect2D::loadLineSpecialChannel2D(XmlStreamReader *xmlreader,
                                     to1, xaxis1, yaxis1);
     // ls1
     lspair.first->setlinetype_lsplot(lstype1);
+    lspair.first->setlegendvisible_lsplot(legendvisible1);
     lspair.first->setlegendtext_lsplot(legend1);
     lspair.first->setlinefillstatus_lsplot(linefill1);
     lspair.first->setlineantialiased_lsplot(lineantialias1);
@@ -1577,6 +1586,7 @@ bool AxisRect2D::loadLineSpecialChannel2D(XmlStreamReader *xmlreader,
     lspair.first->setscatterfillcolor_lsplot(scatterbrush1.color());
     // ls2
     lspair.second->setlinetype_lsplot(lstype2);
+    lspair.second->setlegendvisible_lsplot(legendvisible1);
     lspair.second->setlegendtext_lsplot(legend2);
     lspair.second->setlinefillstatus_lsplot(linefill2);
     lspair.second->setlineantialiased_lsplot(lineantialias2);

--- a/alphaplot/src/2Dplot/AxisRect2D.cpp
+++ b/alphaplot/src/2Dplot/AxisRect2D.cpp
@@ -1586,7 +1586,7 @@ bool AxisRect2D::loadLineSpecialChannel2D(XmlStreamReader *xmlreader,
     lspair.first->setscatterfillcolor_lsplot(scatterbrush1.color());
     // ls2
     lspair.second->setlinetype_lsplot(lstype2);
-    lspair.second->setlegendvisible_lsplot(legendvisible1);
+    lspair.second->setlegendvisible_lsplot(legendvisible2);
     lspair.second->setlegendtext_lsplot(legend2);
     lspair.second->setlinefillstatus_lsplot(linefill2);
     lspair.second->setlineantialiased_lsplot(lineantialias2);

--- a/alphaplot/src/2Dplot/AxisRect2D.cpp
+++ b/alphaplot/src/2Dplot/AxisRect2D.cpp
@@ -1962,6 +1962,11 @@ bool AxisRect2D::load(XmlStreamReader *xmlreader, QList<Table *> tabs,
         } else
           xmlreader->raiseError(tr("Curve2D data not found error"));
 
+        bool legendvisible = xmlreader->readAttributeBool("legendvisible", &ok);
+        (ok) ? curve->setlegendvisible_cplot(legendvisible)
+             : xmlreader->raiseWarning(
+                 tr("Curve2D legend visible property setting error"));
+
         while (!xmlreader->atEnd()) {
           xmlreader->readNextStartElement();
           if (xmlreader->isStartElement() && xmlreader->name() != "errorbar") {

--- a/alphaplot/src/2Dplot/Curve2D.cpp
+++ b/alphaplot/src/2Dplot/Curve2D.cpp
@@ -3,7 +3,6 @@
 #include "AxisRect2D.h"
 #include "DataManager2D.h"
 #include "ErrorBar2D.h"
-#include "Legend2D.h"
 #include "Table.h"
 #include "core/Utilities.h"
 #include "future/core/column/Column.h"

--- a/alphaplot/src/2Dplot/Curve2D.cpp
+++ b/alphaplot/src/2Dplot/Curve2D.cpp
@@ -368,11 +368,11 @@ bool Curve2D::getscatterantialiased_cplot() const {
   return antialiasedScatters();
 }
 
-QString Curve2D::getlegendtext_cplot() const { return name(); }
-
 bool Curve2D::getlegendvisible_cplot() const {
   return mParentPlot->legend->hasItemWithPlottable(this);
 }
+
+QString Curve2D::getlegendtext_cplot() const { return name(); }
 
 Axis2D *Curve2D::getxaxis() const { return xAxis_; }
 
@@ -583,11 +583,11 @@ void Curve2D::setlinefillstatus_cplot(const bool value) {
   }
 }
 
-void Curve2D::setlegendtext_cplot(const QString &text) { setName(text); }
-
 void Curve2D::setlegendvisible_cplot(const bool value) {
   (value) ? addToLegend() : removeFromLegend();
 }
+
+void Curve2D::setlegendtext_cplot(const QString &text) { setName(text); }
 
 void Curve2D::setpicker_cplot(const Graph2DCommon::Picker picker) {
   picker_ = picker;
@@ -608,6 +608,9 @@ void Curve2D::save(XmlStreamWriter *xmlwriter, int xaxis, int yaxis) {
       break;
   }
 
+  (getlegendvisible_cplot())
+    ? xmlwriter->writeAttribute("legendvisible", "true")
+    : xmlwriter->writeAttribute("legendvisible", "false");
   xmlwriter->writeAttribute("legend", getlegendtext_cplot());
   // data
   if (curvedata_) {

--- a/alphaplot/src/2Dplot/Curve2D.cpp
+++ b/alphaplot/src/2Dplot/Curve2D.cpp
@@ -3,6 +3,7 @@
 #include "AxisRect2D.h"
 #include "DataManager2D.h"
 #include "ErrorBar2D.h"
+#include "Legend2D.h"
 #include "Table.h"
 #include "core/Utilities.h"
 #include "future/core/column/Column.h"
@@ -369,6 +370,10 @@ bool Curve2D::getscatterantialiased_cplot() const {
 
 QString Curve2D::getlegendtext_cplot() const { return name(); }
 
+bool Curve2D::getlegendvisible_cplot() const {
+  return mParentPlot->legend->hasItemWithPlottable(this);
+}
+
 Axis2D *Curve2D::getxaxis() const { return xAxis_; }
 
 Axis2D *Curve2D::getyaxis() const { return yAxis_; }
@@ -579,6 +584,10 @@ void Curve2D::setlinefillstatus_cplot(const bool value) {
 }
 
 void Curve2D::setlegendtext_cplot(const QString &text) { setName(text); }
+
+void Curve2D::setlegendvisible_cplot(const bool value) {
+  (value) ? addToLegend() : removeFromLegend();
+}
 
 void Curve2D::setpicker_cplot(const Graph2DCommon::Picker picker) {
   picker_ = picker;

--- a/alphaplot/src/2Dplot/Curve2D.h
+++ b/alphaplot/src/2Dplot/Curve2D.h
@@ -50,6 +50,7 @@ class Curve2D : public QCPCurve {
   QPen getscatterpen_cplot() const;
   bool getscatterantialiased_cplot() const;
   QString getlegendtext_cplot() const;
+  bool getlegendvisible_cplot() const;
   Axis2D *getxaxis() const;
   Axis2D *getyaxis() const;
   Graph2DCommon::PlotType getplottype_cplot() const { return type_; }
@@ -78,6 +79,7 @@ class Curve2D : public QCPCurve {
   void setscatterantialiased_cplot(const bool value);
   void setlinefillstatus_cplot(const bool value);
   void setlegendtext_cplot(const QString &text);
+  void setlegendvisible_cplot(const bool value);
   void setpicker_cplot(const Graph2DCommon::Picker picker);
 
   void save(XmlStreamWriter *xmlwriter, int xaxis, int yaxis);

--- a/alphaplot/src/2Dplot/Curve2D.h
+++ b/alphaplot/src/2Dplot/Curve2D.h
@@ -49,8 +49,8 @@ class Curve2D : public QCPCurve {
   double getscatterstrokethickness_cplot() const;
   QPen getscatterpen_cplot() const;
   bool getscatterantialiased_cplot() const;
-  QString getlegendtext_cplot() const;
   bool getlegendvisible_cplot() const;
+  QString getlegendtext_cplot() const;
   Axis2D *getxaxis() const;
   Axis2D *getyaxis() const;
   Graph2DCommon::PlotType getplottype_cplot() const { return type_; }
@@ -78,8 +78,8 @@ class Curve2D : public QCPCurve {
   void setscatterstrokethickness_cplot(const double value);
   void setscatterantialiased_cplot(const bool value);
   void setlinefillstatus_cplot(const bool value);
-  void setlegendtext_cplot(const QString &text);
   void setlegendvisible_cplot(const bool value);
+  void setlegendtext_cplot(const QString &text);
   void setpicker_cplot(const Graph2DCommon::Picker picker);
 
   void save(XmlStreamWriter *xmlwriter, int xaxis, int yaxis);

--- a/alphaplot/src/2Dplot/Legend2D.cpp
+++ b/alphaplot/src/2Dplot/Legend2D.cpp
@@ -153,6 +153,10 @@ void Legend2D::save(XmlStreamWriter *xmlwriter) {
   xmlwriter->writeAttribute("iconheight", QString::number(iconSize().height()));
   xmlwriter->writeAttribute("icontextpadding",
                             QString::number(iconTextPadding()));
+  xmlwriter->writeAttribute("marginleft", QString::number(margins().left()));
+  xmlwriter->writeAttribute("margintop", QString::number(margins().top()));
+  xmlwriter->writeAttribute("marginright", QString::number(margins().right()));
+  xmlwriter->writeAttribute("marginbottom", QString::number(margins().bottom()));
   xmlwriter->writeStartElement("legend");
   (istitle_legend()) ? xmlwriter->writeAttribute("visible", "true")
                      : xmlwriter->writeAttribute("visible", "false");
@@ -210,6 +214,30 @@ bool Legend2D::load(XmlStreamReader *xmlreader) {
     (ok) ? setIconTextPadding(icontextpadding)
          : xmlreader->raiseError(
                tr("no Legend2D icon text padding property element found"));
+    // margin property
+    if (ok) {
+      int left = xmlreader->readAttributeInt("marginleft", &ok);
+      if (ok) {
+        int top = xmlreader->readAttributeInt("margintop", &ok);
+        if (ok) {
+          int right = xmlreader->readAttributeInt("marginright", &ok);
+          if (ok) {
+            int bottom = xmlreader->readAttributeInt("marginbottom", &ok);
+            if (ok)
+              setMargins(QMargins(left, top, right, bottom));
+            else
+              xmlreader->raiseWarning(
+                  tr("Legend2D bottom margin property setting error"));
+          } else
+            xmlreader->raiseWarning(
+                tr("Legend2D right margin property setting error"));
+        } else
+          xmlreader->raiseWarning(
+              tr("Legend2D top margin property setting error"));
+      } else
+        xmlreader->raiseWarning(
+            tr("Legend2D left margin property setting error"));
+    }
     // font
     while (!xmlreader->atEnd()) {
       xmlreader->readNext();

--- a/alphaplot/src/2Dplot/Legend2D.cpp
+++ b/alphaplot/src/2Dplot/Legend2D.cpp
@@ -21,6 +21,13 @@ Legend2D::~Legend2D() {}
 
 bool Legend2D::gethidden_legend() const { return visible(); }
 
+int Legend2D::getdirection_legend() const {
+  switch (mFillOrder) {
+    case foRowsFirst: return 0;
+    case foColumnsFirst: return 1;
+  }
+}
+
 QColor Legend2D::getborderstrokecolor_legend() const {
   return borderPen().color();
 }
@@ -40,6 +47,17 @@ QPointF Legend2D::getposition_legend() const {
 AxisRect2D *Legend2D::getaxisrect_legend() const { return axisrect_; }
 
 void Legend2D::sethidden_legend(const bool status) { setVisible(status); }
+
+void Legend2D::setdirection_legend(const int type) {
+  switch (type) {
+    case 0:
+      setFillOrder(QCPLegend::foRowsFirst);
+      break;
+    case 1:
+      setFillOrder(QCPLegend::foColumnsFirst);
+      break;
+  }
+}
 
 void Legend2D::setborderstrokecolor_legend(const QColor &color) {
   QPen p = borderPen();
@@ -153,6 +171,14 @@ void Legend2D::save(XmlStreamWriter *xmlwriter) {
   xmlwriter->writeAttribute("iconheight", QString::number(iconSize().height()));
   xmlwriter->writeAttribute("icontextpadding",
                             QString::number(iconTextPadding()));
+  switch (getdirection_legend()) {
+    case QCPLegend::foRowsFirst:
+      xmlwriter->writeAttribute("direction", "rows");
+      break;
+    case QCPLegend::foColumnsFirst:
+      xmlwriter->writeAttribute("direction", "columns");
+      break;
+  }
   xmlwriter->writeAttribute("marginleft", QString::number(margins().left()));
   xmlwriter->writeAttribute("margintop", QString::number(margins().top()));
   xmlwriter->writeAttribute("marginright", QString::number(margins().right()));
@@ -214,6 +240,18 @@ bool Legend2D::load(XmlStreamReader *xmlreader) {
     (ok) ? setIconTextPadding(icontextpadding)
          : xmlreader->raiseError(
                tr("no Legend2D icon text padding property element found"));
+    // direction
+    QString direction = xmlreader->readAttributeString("direction", &ok);
+    if (ok) {
+      if (direction == "rows")
+        setdirection_legend(0);
+      else if (direction == "columns")
+        setdirection_legend(1);
+      else
+        xmlreader->raiseWarning(tr("Legend2D unknown direction"));
+    } else
+      xmlreader->raiseWarning(
+          tr("Legend2D direction property setting error"));
     // margin property
     if (ok) {
       int left = xmlreader->readAttributeInt("marginleft", &ok);

--- a/alphaplot/src/2Dplot/Legend2D.cpp
+++ b/alphaplot/src/2Dplot/Legend2D.cpp
@@ -276,33 +276,6 @@ bool Legend2D::load(XmlStreamReader *xmlreader) {
         xmlreader->raiseWarning(
             tr("Legend2D left margin property setting error"));
     }
-    // legend title
-    while (!xmlreader->atEnd()) {
-      xmlreader->readNext();
-      if (xmlreader->isEndElement() && xmlreader->name() == "legend") break;
-      if (xmlreader->isStartElement() && xmlreader->name() == "legend") {
-        bool visible = xmlreader->readAttributeBool("visible", &ok);
-        if (visible) addtitle_legend();
-        QString itemtext = xmlreader->readAttributeString("text", &ok);
-        if (ok)
-          settitletext_legend(itemtext);
-        else {
-          settitletext_legend("Title");
-          xmlreader->raiseWarning(
-              tr("Legend2D title text property setting error"));
-        }
-      }
-      // title font
-      if (xmlreader->isStartElement() && xmlreader->name() == "font") {
-        QPair<QFont, QColor> fontpair = xmlreader->readFont(&ok);
-        if (ok) {
-          settitlefont_legend(fontpair.first);
-          settitlecolor_legend(fontpair.second);
-        } else
-          xmlreader->raiseWarning(
-              tr("Legend2D title font property setting error"));
-      }
-    }
     // font
     while (!xmlreader->atEnd()) {
       xmlreader->readNext();

--- a/alphaplot/src/2Dplot/Legend2D.cpp
+++ b/alphaplot/src/2Dplot/Legend2D.cpp
@@ -238,6 +238,33 @@ bool Legend2D::load(XmlStreamReader *xmlreader) {
         xmlreader->raiseWarning(
             tr("Legend2D left margin property setting error"));
     }
+    // legend title
+    while (!xmlreader->atEnd()) {
+      xmlreader->readNext();
+      if (xmlreader->isEndElement() && xmlreader->name() == "legend") break;
+      if (xmlreader->isStartElement() && xmlreader->name() == "legend") {
+        bool visible = xmlreader->readAttributeBool("visible", &ok);
+        if (visible) addtitle_legend();
+        QString itemtext = xmlreader->readAttributeString("text", &ok);
+        if (ok)
+          settitletext_legend(itemtext);
+        else {
+          settitletext_legend("Title");
+          xmlreader->raiseWarning(
+              tr("Legend2D title text property setting error"));
+        }
+      }
+      // title font
+      if (xmlreader->isStartElement() && xmlreader->name() == "font") {
+        QPair<QFont, QColor> fontpair = xmlreader->readFont(&ok);
+        if (ok) {
+          settitlefont_legend(fontpair.first);
+          settitlecolor_legend(fontpair.second);
+        } else
+          xmlreader->raiseWarning(
+              tr("Legend2D title font property setting error"));
+      }
+    }
     // font
     while (!xmlreader->atEnd()) {
       xmlreader->readNext();

--- a/alphaplot/src/2Dplot/Legend2D.h
+++ b/alphaplot/src/2Dplot/Legend2D.h
@@ -17,6 +17,7 @@ class Legend2D : public QCPLegend {
   ~Legend2D();
 
   bool gethidden_legend() const;
+  int getdirection_legend() const;
   QColor getborderstrokecolor_legend() const;
   double getborderstrokethickness_legend() const;
   Qt::PenStyle getborderstrokestyle_legend() const;
@@ -24,6 +25,7 @@ class Legend2D : public QCPLegend {
   AxisRect2D *getaxisrect_legend() const;
 
   void sethidden_legend(const bool status);
+  void setdirection_legend(const int type);
   void setborderstrokecolor_legend(const QColor &color);
   void setborderstrokethickness_legend(const double value);
   void setborderstrokestyle_legend(const Qt::PenStyle &style);

--- a/alphaplot/src/2Dplot/LineSpecial2D.cpp
+++ b/alphaplot/src/2Dplot/LineSpecial2D.cpp
@@ -239,6 +239,10 @@ bool LineSpecial2D::getscatterantialiased_lsplot() const {
   return antialiasedScatters();
 }
 
+bool LineSpecial2D::getlegendvisible_lsplot() const {
+  return mParentPlot->legend->hasItemWithPlottable(this);
+}
+
 QString LineSpecial2D::getlegendtext_lsplot() const { return name(); }
 
 Axis2D *LineSpecial2D::getxaxis() const { return xAxis_; }
@@ -406,6 +410,10 @@ void LineSpecial2D::setscatterantialiased_lsplot(const bool value) {
   setAntialiasedScatters(value);
 }
 
+void LineSpecial2D::setlegendvisible_lsplot(const bool value) {
+  (value) ? addToLegend() : removeFromLegend();
+}
+
 void LineSpecial2D::setlegendtext_lsplot(const QString &legendtext) {
   setName(legendtext);
 }
@@ -438,6 +446,9 @@ void LineSpecial2D::save(XmlStreamWriter *xmlwriter, int xaxis, int yaxis) {
   xmlwriter->writeAttribute("xaxis", QString::number(xaxis));
   xmlwriter->writeAttribute("yaxis", QString::number(yaxis));
 
+  (getlegendvisible_lsplot())
+    ? xmlwriter->writeAttribute("legendvisible", "true")
+    : xmlwriter->writeAttribute("legendvisible", "false");
   xmlwriter->writeAttribute("legend", getlegendtext_lsplot());
   // data
   xmlwriter->writeAttribute("table", graphdata_->gettable()->name());

--- a/alphaplot/src/2Dplot/LineSpecial2D.h
+++ b/alphaplot/src/2Dplot/LineSpecial2D.h
@@ -40,6 +40,7 @@ class LineSpecial2D : public QCPGraph {
   QColor getscatterstrokecolor_lsplot() const;
   double getscatterstrokethickness_lsplot() const;
   bool getscatterantialiased_lsplot() const;
+  bool getlegendvisible_lsplot() const;
   QString getlegendtext_lsplot() const;
   Axis2D *getxaxis() const;
   Axis2D *getyaxis() const;
@@ -62,6 +63,7 @@ class LineSpecial2D : public QCPGraph {
   void setscatterstrokecolor_lsplot(const QColor &color);
   void setscatterstrokethickness_lsplot(const double value);
   void setscatterantialiased_lsplot(const bool value);
+  void setlegendvisible_lsplot(const bool value);
   void setlegendtext_lsplot(const QString &legendtext);
   void setxaxis_lsplot(Axis2D *axis);
   void setyaxis_lsplot(Axis2D *axis);

--- a/alphaplot/src/2Dplot/TextItem2D.cpp
+++ b/alphaplot/src/2Dplot/TextItem2D.cpp
@@ -215,7 +215,7 @@ bool TextItem2D::load(XmlStreamReader *xmlreader) {
     else {
       setText("Text");
       xmlreader->raiseWarning(
-          tr("TextItem2D y position property setting error"));
+          tr("TextItem2D text property setting error"));
     }
 
     // rotation

--- a/alphaplot/src/2Dplot/Vector2D.cpp
+++ b/alphaplot/src/2Dplot/Vector2D.cpp
@@ -292,6 +292,10 @@ bool Vector2D::getendinverted_vecplot(
   return ending->inverted();
 }
 
+bool Vector2D::getlegendvisible_vecplot() const {
+  return mParentPlot->legend->hasItemWithPlottable(this);
+}
+
 QString Vector2D::getlegendtext_vecplot() const { return name(); }
 
 void Vector2D::setxaxis_vecplot(Axis2D *axis) {
@@ -442,6 +446,10 @@ void Vector2D::setendinverted_vecplot(
   reloadendings(location);
 }
 
+void Vector2D::setlegendvisible_vecplot(const bool value) {
+  (value) ? addToLegend() : removeFromLegend();
+}
+
 void Vector2D::setlegendtext_vecplot(const QString &name) { setName(name); }
 
 void Vector2D::save(XmlStreamWriter *xmlwriter, int xaxis, int yaxis) {
@@ -459,6 +467,9 @@ void Vector2D::save(XmlStreamWriter *xmlwriter, int xaxis, int yaxis) {
   xmlwriter->writeAttribute("y2column", y2col_->name());
   xmlwriter->writeAttribute("from", QString::number(from_));
   xmlwriter->writeAttribute("to", QString::number(to_));
+  (getlegendvisible_vecplot())
+    ? xmlwriter->writeAttribute("legendvisible", "true")
+    : xmlwriter->writeAttribute("legendvisible", "false");
   xmlwriter->writeAttribute("legend", getlegendtext_vecplot());
   (getlineantialiased_vecplot())
       ? xmlwriter->writeAttribute("antialias", "true")
@@ -513,7 +524,7 @@ bool Vector2D::load(XmlStreamReader *xmlreader) {
   if (xmlreader->isStartElement() && xmlreader->name() == "vector") {
     bool ok;
 
-    // line antialias
+    // legend text
     QString legend = xmlreader->readAttributeString("legend", &ok);
     (ok) ? setlegendtext_vecplot(legend)
          : xmlreader->raiseWarning(
@@ -587,6 +598,12 @@ bool Vector2D::load(XmlStreamReader *xmlreader) {
               tr("Vector2D strokepen property setting error"));
       }
     }
+
+    // legend visible
+    bool legendvisible = xmlreader->readAttributeBool("legendvisible", &ok);
+    (ok) ? setlegendvisible_vecplot(legendvisible)
+         : xmlreader->raiseWarning(
+           tr("Curve2D legend visible property setting error"));
 
   } else  // no element
     xmlreader->raiseError(tr("no Vector2D item element found"));

--- a/alphaplot/src/2Dplot/Vector2D.h
+++ b/alphaplot/src/2Dplot/Vector2D.h
@@ -49,6 +49,7 @@ class Vector2D : public QCPGraph {
   double getendwidth_vecplot(const LineEndLocation &location) const;
   double getendheight_vecplot(const LineEndLocation &location) const;
   bool getendinverted_vecplot(const LineEndLocation &location) const;
+  bool getlegendvisible_vecplot() const;
   QString getlegendtext_vecplot() const;
   Table *gettable_vecplot() const { return table_; }
   Column *getfirstcol_vecplot() const { return x1col_; }
@@ -71,6 +72,7 @@ class Vector2D : public QCPGraph {
                             const LineEndLocation &location);
   void setendinverted_vecplot(const bool value,
                               const LineEndLocation &location);
+  void setlegendvisible_vecplot(const bool value);
   void setlegendtext_vecplot(const QString &name);
 
   void save(XmlStreamWriter *xmlwriter, int xaxis, int yaxis);

--- a/alphaplot/src/ApplicationWindow.cpp
+++ b/alphaplot/src/ApplicationWindow.cpp
@@ -8197,7 +8197,7 @@ bool ApplicationWindow::validFor2DPlot(Table *table, Graph type) {
           table->selectedColumnCount(AlphaPlot::Y) < 2) {
         QMessageBox::warning(
             this, tr("Error"),
-            tr("Please select one X & nultiple Y column(s) to plot!"));
+            tr("Please select one X & multiple Y column(s) to plot!"));
         return false;
       } else if (table->selectedColumnCount(AlphaPlot::Z) > 0) {
         QMessageBox::warning(

--- a/alphaplot/src/core/widgets/propertyeditor.cpp
+++ b/alphaplot/src/core/widgets/propertyeditor.cpp
@@ -321,6 +321,7 @@ PropertyEditor::PropertyEditor(QWidget *parent, ApplicationWindow *app)
   itempropertylegendoriginxitem_ = doubleManager_->addProperty("Position X");
   itempropertylegendoriginyitem_ = doubleManager_->addProperty("Position Y");
   itempropertylegendvisibleitem_ = boolManager_->addProperty("Visible");
+  itempropertylegendmarginitem_ = rectManager_->addProperty("Margin");
   itempropertylegendfontitem_ = fontManager_->addProperty("Font");
   itempropertylegendtextcoloritem_ = colorManager_->addProperty("Text color");
   itempropertylegendiconwidthitem_ = intManager_->addProperty("Icon width");
@@ -2309,7 +2310,17 @@ void PropertyEditor::valueChange(QtProperty *prop, const QRect &rect) {
         getgraph2dobject<MyWidget>(objectbrowser_->currentItem());
     if (widget->geometry() == rect) return;
     widget->setGeometry(rect);
-  } else if (prop->compare(itempropertytextmarginitem_)) {
+  } else if (prop->compare(itempropertylegendmarginitem_)) {
+    Legend2D *legend =
+        getgraph2dobject<Legend2D>(objectbrowser_->currentItem());
+    QMargins margin;
+    margin.setLeft(rect.left());
+    margin.setTop(rect.top());
+    margin.setRight(rect.right());
+    margin.setBottom(rect.bottom());
+    legend->setMargins(margin);
+    legend->layer()->replot();
+    } else if (prop->compare(itempropertytextmarginitem_)) {
     TextItem2D *textitem =
         getgraph2dobject<TextItem2D>(objectbrowser_->currentItem());
     QMargins margin;
@@ -4231,6 +4242,7 @@ void PropertyEditor::Legend2DPropertyBlock(Legend2D *legend) {
   propertybrowser_->addProperty(itempropertylegendoriginxitem_);
   propertybrowser_->addProperty(itempropertylegendoriginyitem_);
   propertybrowser_->addProperty(itempropertylegendvisibleitem_);
+  propertybrowser_->addProperty(itempropertylegendmarginitem_);
   propertybrowser_->addProperty(itempropertylegendfontitem_);
   propertybrowser_->addProperty(itempropertylegendtextcoloritem_);
   propertybrowser_->addProperty(itempropertylegendiconwidthitem_);
@@ -4249,6 +4261,12 @@ void PropertyEditor::Legend2DPropertyBlock(Legend2D *legend) {
                            legend->getposition_legend().y());
   boolManager_->setValue(itempropertylegendvisibleitem_,
                          legend->gethidden_legend());
+  QRect rect;
+  rect.setLeft(legend->margins().left());
+  rect.setTop(legend->margins().top());
+  rect.setRight(legend->margins().right());
+  rect.setBottom(legend->margins().bottom());
+  rectManager_->setValue(itempropertylegendmarginitem_, rect);
   fontManager_->setValue(itempropertylegendfontitem_, legend->font());
   colorManager_->setValue(itempropertylegendtextcoloritem_,
                           legend->textColor());
@@ -7028,6 +7046,7 @@ void PropertyEditor::setObjectPropertyId() {
       "itempropertylegendoriginyitem_");
   itempropertylegendvisibleitem_->setPropertyId(
       "itempropertylegendvisibleitem_");
+  itempropertylegendmarginitem_->setPropertyId("itempropertylegendmarginitem_");
   itempropertylegendfontitem_->setPropertyId("itempropertylegendfontitem_");
   itempropertylegendtextcoloritem_->setPropertyId(
       "itempropertylegendtextcoloritem_");

--- a/alphaplot/src/core/widgets/propertyeditor.cpp
+++ b/alphaplot/src/core/widgets/propertyeditor.cpp
@@ -682,7 +682,9 @@ PropertyEditor::PropertyEditor(QWidget *parent, ApplicationWindow *app)
                              stroketypeiconslist);
   cplotpropertyscatterantialiaseditem_ =
       boolManager_->addProperty("Scatter Antialiased");
-  cplotpropertylegendtextitem_ = stringManager_->addProperty("Plot Legrad");
+  cplotpropertylegendtextitem_ = stringManager_->addProperty("Plot Legend");
+  cplotpropertylegendvisibleitem_ =
+      boolManager_->addProperty("Legend Visible");
 
   // Box Properties block
   barplotpropertyxaxisitem_ = enumManager_->addProperty("X Axis");
@@ -1665,6 +1667,10 @@ void PropertyEditor::valueChange(QtProperty *prop, const bool value) {
     Curve2D *curve = getgraph2dobject<Curve2D>(objectbrowser_->currentItem());
     curve->setscatterantialiased_cplot(value);
     curve->layer()->replot();
+  } else if (prop->compare(cplotpropertylegendvisibleitem_)) {
+    Curve2D *curve = getgraph2dobject<Curve2D>(objectbrowser_->currentItem());
+    curve->setlegendvisible_cplot(value);
+    curve->getxaxis()->getaxisrect_axis()->getLegend()->layer()->replot();
   } else if (prop->compare(barplotpropertyfillantialiaseditem_)) {
     Bar2D *bar = getgraph2dobject<Bar2D>(objectbrowser_->currentItem());
     bar->setAntialiasedFill(value);
@@ -4589,6 +4595,7 @@ void PropertyEditor::Curve2DPropertyBlock(Curve2D *curve,
   propertybrowser_->addProperty(cplotpropertyscatterstrokethicknessitem_);
   propertybrowser_->addProperty(cplotpropertyscatterantialiaseditem_);
   propertybrowser_->addProperty(cplotpropertylegendtextitem_);
+  propertybrowser_->addProperty(cplotpropertylegendvisibleitem_);
   {
     QStringList cyaxislist;
     int currentyaxis = 0;
@@ -4657,6 +4664,8 @@ void PropertyEditor::Curve2DPropertyBlock(Curve2D *curve,
                          curve->getscatterantialiased_cplot());
   stringManager_->setValue(cplotpropertylegendtextitem_,
                            Utilities::joinstring(curve->getlegendtext_cplot()));
+  boolManager_->setValue(cplotpropertylegendvisibleitem_,
+                         curve->getlegendvisible_cplot());
 }
 
 void PropertyEditor::Bar2DPropertyBlock(Bar2D *bargraph, AxisRect2D *axisrect) {
@@ -7204,7 +7213,9 @@ void PropertyEditor::setObjectPropertyId() {
       "cplotpropertyscatterstrokestyleitem_");
   cplotpropertyscatterantialiaseditem_->setPropertyId(
       "cplotpropertyscatterantialiaseditem_");
-  cplotpropertylegendtextitem_->setPropertyId("cplotpropertylelegendtextitem_");
+  cplotpropertylegendtextitem_->setPropertyId("cplotpropertylegendtextitem_");
+  cplotpropertylegendvisibleitem_->setPropertyId(
+      "cplotpropertylegendvisibleitem_");
 
   // Box Properties block
   barplotpropertyxaxisitem_->setPropertyId("barplotpropertyxaxisitem_");

--- a/alphaplot/src/core/widgets/propertyeditor.cpp
+++ b/alphaplot/src/core/widgets/propertyeditor.cpp
@@ -505,8 +505,11 @@ PropertyEditor::PropertyEditor(QWidget *parent, ApplicationWindow *app)
   // LineSpecialChannel Properties block
   channelplotpropertyxaxisitem_ = enumManager_->addProperty("X Axis");
   channelplotpropertyyaxisitem_ = enumManager_->addProperty("Y Axis");
+  channelplotpropertylegendvisibleitem_ = boolManager_->addProperty("Legend");
   channelplotpropertylegendtextitem_ =
-      stringManager_->addProperty("Plot Legrad");
+      stringManager_->addProperty("Plot Legend");
+  channelplotpropertylegendvisibleitem_->addSubProperty(
+      channelplotpropertylegendtextitem_);
   // channel 1st graph
   channel1plotpropertygroupitem_ =
       groupManager_->addProperty("Channel Border 1");
@@ -846,7 +849,10 @@ PropertyEditor::PropertyEditor(QWidget *parent, ApplicationWindow *app)
       doubleManager_->addProperty("Line Ending Width");
   vectorpropertylineantialiaseditem_ =
       boolManager_->addProperty("Line Antialiased");
-  vectorpropertylegendtextitem_ = stringManager_->addProperty("Plot Legrad");
+  vectorpropertylegendvisibleitem_ = boolManager_->addProperty("Legend");
+  vectorpropertylegendtextitem_ = stringManager_->addProperty("Plot Legend");
+  vectorpropertylegendvisibleitem_->addSubProperty(
+    vectorpropertylegendtextitem_);
 
   // Pie Properties Block
   QStringList piestyle;
@@ -1662,6 +1668,14 @@ void PropertyEditor::valueChange(QtProperty *prop, const bool value) {
     LineSpecial2D *lsgraph = static_cast<LineSpecial2D *>(ptr);
     lsgraph->setscatterantialiased_lsplot(value);
     lsgraph->layer()->replot();
+  } else if (prop->compare(channelplotpropertylegendvisibleitem_)) {
+    void *ptr = objectbrowser_->currentItem()
+                    ->data(0, Qt::UserRole + 1)
+                    .value<void *>();
+    LineSpecial2D *lsgraph = static_cast<LineSpecial2D *>(ptr);
+    channelplotpropertylegendtextitem_->setEnabled(value);
+    lsgraph->setlegendvisible_lsplot(value);
+    lsgraph->getxaxis()->getaxisrect_axis()->getLegend()->layer()->replot();
   } else if (prop->compare(cplotpropertylinefillstatusitem_)) {
     Curve2D *curve = getgraph2dobject<Curve2D>(objectbrowser_->currentItem());
     curve->setlinefillstatus_cplot(value);
@@ -1735,6 +1749,12 @@ void PropertyEditor::valueChange(QtProperty *prop, const bool value) {
         getgraph2dobject<Vector2D>(objectbrowser_->currentItem());
     vector->setlineantialiased_vecplot(value);
     vector->parentPlot()->replot(QCustomPlot::RefreshPriority::rpQueuedReplot);
+  } else if (prop->compare(vectorpropertylegendvisibleitem_)) {
+    Vector2D *vector =
+        getgraph2dobject<Vector2D>(objectbrowser_->currentItem());
+    vectorpropertylegendtextitem_->setEnabled(value);
+    vector->setlegendvisible_vecplot(value);
+    vector->getxaxis()->getaxisrect_axis()->getLegend()->layer()->replot();
   } else if (prop->compare(colormappropertyinterpolateitem_)) {
     ColorMap2D *colormap =
         getgraph2dobject<ColorMap2D>(objectbrowser_->currentItem());
@@ -4487,7 +4507,7 @@ void PropertyEditor::LineSpecialChannel2DPropertyBlock(LineSpecial2D *lsgraph1,
   propertybrowser_->clear();
   propertybrowser_->addProperty(channelplotpropertyxaxisitem_);
   propertybrowser_->addProperty(channelplotpropertyyaxisitem_);
-  propertybrowser_->addProperty(channelplotpropertylegendtextitem_);
+  propertybrowser_->addProperty(channelplotpropertylegendvisibleitem_);
   propertybrowser_->addProperty(channel1plotpropertygroupitem_);
   propertybrowser_->addProperty(channel2plotpropertygroupitem_);
 
@@ -4525,6 +4545,8 @@ void PropertyEditor::LineSpecialChannel2DPropertyBlock(LineSpecial2D *lsgraph1,
     enumManager_->setValue(channelplotpropertyxaxisitem_, currentxaxis);
   }
 
+  boolManager_->setValue(channelplotpropertylegendvisibleitem_,
+                         lsgraph1->getlegendvisible_lsplot());
   stringManager_->setValue(
       channelplotpropertylegendtextitem_,
       Utilities::joinstring(lsgraph1->getlegendtext_lsplot()));
@@ -4932,7 +4954,7 @@ void PropertyEditor::Vector2DPropertyBlock(Vector2D *vectorgraph,
   propertybrowser_->addProperty(vectorpropertylineendingheightitem_);
   propertybrowser_->addProperty(vectorpropertylineendingwidthitem_);
   propertybrowser_->addProperty(vectorpropertylineantialiaseditem_);
-  propertybrowser_->addProperty(vectorpropertylegendtextitem_);
+  propertybrowser_->addProperty(vectorpropertylegendvisibleitem_);
   {
     QStringList vectoryaxislist;
     int currentyaxis = 0;
@@ -4984,6 +5006,8 @@ void PropertyEditor::Vector2DPropertyBlock(Vector2D *vectorgraph,
       vectorgraph->getendwidth_vecplot(Vector2D::LineEndLocation::Head));
   boolManager_->setValue(vectorpropertylineantialiaseditem_,
                          vectorgraph->getlineantialiased_vecplot());
+  boolManager_->setValue(vectorpropertylegendvisibleitem_,
+                         vectorgraph->getlegendvisible_vecplot());
   stringManager_->setValue(
       vectorpropertylegendtextitem_,
       Utilities::joinstring(vectorgraph->getlegendtext_vecplot()));
@@ -7137,6 +7161,8 @@ void PropertyEditor::setObjectPropertyId() {
   // LineSpecialChannel Properties block
   channelplotpropertyxaxisitem_->setPropertyId("channelplotpropertyxaxisitem_");
   channelplotpropertyyaxisitem_->setPropertyId("channelplotpropertyyaxisitem_");
+  channelplotpropertylegendvisibleitem_->setPropertyId(
+      "channelplotpropertylegendvisibleitem_");
   channelplotpropertylegendtextitem_->setPropertyId(
       "channelplotpropertylegendtextitem_");
   channel1plotpropertygroupitem_->setPropertyId(
@@ -7336,6 +7362,8 @@ void PropertyEditor::setObjectPropertyId() {
       "vectorpropertylineendingwidthitem_");
   vectorpropertylineantialiaseditem_->setPropertyId(
       "vectorpropertylineantialiaseditem_");
+  vectorpropertylegendvisibleitem_->setPropertyId(
+      "vectorpropertylegendvisibleitem_");
   vectorpropertylegendtextitem_->setPropertyId("vectorpropertylegendtextitem_");
 
   // Pie Properties Block

--- a/alphaplot/src/core/widgets/propertyeditor.cpp
+++ b/alphaplot/src/core/widgets/propertyeditor.cpp
@@ -498,7 +498,10 @@ PropertyEditor::PropertyEditor(QWidget *parent, ApplicationWindow *app)
                              stroketypeiconslist);
   lsplotpropertyscatterantialiaseditem_ =
       boolManager_->addProperty("Scatter Antialiased");
-  lsplotpropertylegendtextitem_ = stringManager_->addProperty("Plot Legrad");
+  lsplotpropertylegendvisibleitem_ = boolManager_->addProperty("Legend");
+  lsplotpropertylegendtextitem_ = stringManager_->addProperty("Plot Legend");
+  lsplotpropertylegendvisibleitem_->addSubProperty(
+      lsplotpropertylegendtextitem_);
   // LineSpecialChannel Properties block
   channelplotpropertyxaxisitem_ = enumManager_->addProperty("X Axis");
   channelplotpropertyyaxisitem_ = enumManager_->addProperty("Y Axis");
@@ -682,8 +685,7 @@ PropertyEditor::PropertyEditor(QWidget *parent, ApplicationWindow *app)
                              stroketypeiconslist);
   cplotpropertyscatterantialiaseditem_ =
       boolManager_->addProperty("Scatter Antialiased");
-  cplotpropertylegendvisibleitem_ =
-      boolManager_->addProperty("Legend");
+  cplotpropertylegendvisibleitem_ = boolManager_->addProperty("Legend");
   cplotpropertylegendtextitem_ = stringManager_->addProperty("Plot Legend");
   cplotpropertylegendvisibleitem_->addSubProperty(
       cplotpropertylegendtextitem_);
@@ -1626,6 +1628,12 @@ void PropertyEditor::valueChange(QtProperty *prop, const bool value) {
         getgraph2dobject<LineSpecial2D>(objectbrowser_->currentItem());
     lsgraph->setscatterantialiased_lsplot(value);
     lsgraph->layer()->replot();
+  } else if (prop->compare(lsplotpropertylegendvisibleitem_)) {
+    LineSpecial2D *lsgraph =
+        getgraph2dobject<LineSpecial2D>(objectbrowser_->currentItem());
+    lsplotpropertylegendtextitem_->setEnabled(value);
+    lsgraph->setlegendvisible_lsplot(value);
+    lsgraph->getxaxis()->getaxisrect_axis()->getLegend()->layer()->replot();
   } else if (prop->compare(channel1plotpropertylineantialiaseditem_)) {
     void *ptr = objectbrowser_->currentItem()
                     ->data(0, Qt::UserRole + 1)
@@ -4399,7 +4407,7 @@ void PropertyEditor::LineSpecial2DPropertyBlock(LineSpecial2D *lsgraph,
   propertybrowser_->addProperty(lsplotpropertyscatterstrokestyleitem_);
   propertybrowser_->addProperty(lsplotpropertyscatterstrokethicknessitem_);
   propertybrowser_->addProperty(lsplotpropertyscatterantialiaseditem_);
-  propertybrowser_->addProperty(lsplotpropertylegendtextitem_);
+  propertybrowser_->addProperty(lsplotpropertylegendvisibleitem_);
   {
     QStringList lsyaxislist;
     int currentyaxis = 0;
@@ -4466,6 +4474,8 @@ void PropertyEditor::LineSpecial2DPropertyBlock(LineSpecial2D *lsgraph,
                            lsgraph->getscatterstrokethickness_lsplot());
   boolManager_->setValue(lsplotpropertyscatterantialiaseditem_,
                          lsgraph->getscatterantialiased_lsplot());
+  boolManager_->setValue(lsplotpropertylegendvisibleitem_,
+                         lsgraph->getlegendvisible_lsplot());
   stringManager_->setValue(
       lsplotpropertylegendtextitem_,
       Utilities::joinstring(lsgraph->getlegendtext_lsplot()));
@@ -7120,8 +7130,10 @@ void PropertyEditor::setObjectPropertyId() {
       "lsplotpropertyscatterstrokestyleitem_");
   lsplotpropertyscatterantialiaseditem_->setPropertyId(
       "lsplotpropertyscatterantialiaseditem_");
+  lsplotpropertylegendvisibleitem_->setPropertyId(
+      "lsplotpropertylegendvisibleitem_");
   lsplotpropertylegendtextitem_->setPropertyId(
-      "lsplotpropertylelegendtextitem_");
+      "lsplotpropertylegendtextitem_");
   // LineSpecialChannel Properties block
   channelplotpropertyxaxisitem_->setPropertyId("channelplotpropertyxaxisitem_");
   channelplotpropertyyaxisitem_->setPropertyId("channelplotpropertyyaxisitem_");

--- a/alphaplot/src/core/widgets/propertyeditor.cpp
+++ b/alphaplot/src/core/widgets/propertyeditor.cpp
@@ -318,9 +318,13 @@ PropertyEditor::PropertyEditor(QWidget *parent, ApplicationWindow *app)
       axispropertyticklabelprecisionitem_);
   intManager_->setRange(axispropertyticklabelprecisionitem_, 0, 16);
   // Legend Properties
+  QStringList directionlist;
+  directionlist << tr("Rows") << tr("Columns");
   itempropertylegendoriginxitem_ = doubleManager_->addProperty("Position X");
   itempropertylegendoriginyitem_ = doubleManager_->addProperty("Position Y");
   itempropertylegendvisibleitem_ = boolManager_->addProperty("Visible");
+  itempropertylegenddirectionitem_ = enumManager_->addProperty("Direction");
+  enumManager_->setEnumNames(itempropertylegenddirectionitem_, directionlist);
   itempropertylegendmarginitem_ = rectManager_->addProperty("Margin");
   itempropertylegendfontitem_ = fontManager_->addProperty("Font");
   itempropertylegendtextcoloritem_ = colorManager_->addProperty("Text color");
@@ -3148,6 +3152,11 @@ void PropertyEditor::enumValueChange(QtProperty *prop, const int value) {
     b.setStyle(static_cast<Qt::BrushStyle>(value + 1));
     axisrect->setBackground(b);
     axisrect->layer()->replot();
+  } else if (prop->compare(itempropertylegenddirectionitem_)) {
+    Legend2D *legend =
+        getgraph2dobject<Legend2D>(objectbrowser_->currentItem());
+    legend->setdirection_legend(value);
+    legend->layer()->replot();
   } else if (prop->compare(itempropertylegendbackgroundfillstyleitem_)) {
     Legend2D *legend =
         getgraph2dobject<Legend2D>(objectbrowser_->currentItem());
@@ -4242,6 +4251,7 @@ void PropertyEditor::Legend2DPropertyBlock(Legend2D *legend) {
   propertybrowser_->addProperty(itempropertylegendoriginxitem_);
   propertybrowser_->addProperty(itempropertylegendoriginyitem_);
   propertybrowser_->addProperty(itempropertylegendvisibleitem_);
+  propertybrowser_->addProperty(itempropertylegenddirectionitem_);
   propertybrowser_->addProperty(itempropertylegendmarginitem_);
   propertybrowser_->addProperty(itempropertylegendfontitem_);
   propertybrowser_->addProperty(itempropertylegendtextcoloritem_);
@@ -4261,6 +4271,8 @@ void PropertyEditor::Legend2DPropertyBlock(Legend2D *legend) {
                            legend->getposition_legend().y());
   boolManager_->setValue(itempropertylegendvisibleitem_,
                          legend->gethidden_legend());
+  enumManager_->setValue(itempropertylegenddirectionitem_,
+                         static_cast<int>(legend->getdirection_legend()));
   QRect rect;
   rect.setLeft(legend->margins().left());
   rect.setTop(legend->margins().top());
@@ -7046,6 +7058,8 @@ void PropertyEditor::setObjectPropertyId() {
       "itempropertylegendoriginyitem_");
   itempropertylegendvisibleitem_->setPropertyId(
       "itempropertylegendvisibleitem_");
+  itempropertylegenddirectionitem_->setPropertyId(
+      "itempropertylegenddirectionitem_");
   itempropertylegendmarginitem_->setPropertyId("itempropertylegendmarginitem_");
   itempropertylegendfontitem_->setPropertyId("itempropertylegendfontitem_");
   itempropertylegendtextcoloritem_->setPropertyId(

--- a/alphaplot/src/core/widgets/propertyeditor.cpp
+++ b/alphaplot/src/core/widgets/propertyeditor.cpp
@@ -682,9 +682,11 @@ PropertyEditor::PropertyEditor(QWidget *parent, ApplicationWindow *app)
                              stroketypeiconslist);
   cplotpropertyscatterantialiaseditem_ =
       boolManager_->addProperty("Scatter Antialiased");
-  cplotpropertylegendtextitem_ = stringManager_->addProperty("Plot Legend");
   cplotpropertylegendvisibleitem_ =
-      boolManager_->addProperty("Legend Visible");
+      boolManager_->addProperty("Legend");
+  cplotpropertylegendtextitem_ = stringManager_->addProperty("Plot Legend");
+  cplotpropertylegendvisibleitem_->addSubProperty(
+      cplotpropertylegendtextitem_);
 
   // Box Properties block
   barplotpropertyxaxisitem_ = enumManager_->addProperty("X Axis");
@@ -1669,6 +1671,7 @@ void PropertyEditor::valueChange(QtProperty *prop, const bool value) {
     curve->layer()->replot();
   } else if (prop->compare(cplotpropertylegendvisibleitem_)) {
     Curve2D *curve = getgraph2dobject<Curve2D>(objectbrowser_->currentItem());
+    cplotpropertylegendtextitem_->setEnabled(value);
     curve->setlegendvisible_cplot(value);
     curve->getxaxis()->getaxisrect_axis()->getLegend()->layer()->replot();
   } else if (prop->compare(barplotpropertyfillantialiaseditem_)) {
@@ -4594,7 +4597,6 @@ void PropertyEditor::Curve2DPropertyBlock(Curve2D *curve,
   propertybrowser_->addProperty(cplotpropertyscatterstrokestyleitem_);
   propertybrowser_->addProperty(cplotpropertyscatterstrokethicknessitem_);
   propertybrowser_->addProperty(cplotpropertyscatterantialiaseditem_);
-  propertybrowser_->addProperty(cplotpropertylegendtextitem_);
   propertybrowser_->addProperty(cplotpropertylegendvisibleitem_);
   {
     QStringList cyaxislist;
@@ -4662,10 +4664,10 @@ void PropertyEditor::Curve2DPropertyBlock(Curve2D *curve,
                            curve->getscatterstrokethickness_cplot());
   boolManager_->setValue(cplotpropertyscatterantialiaseditem_,
                          curve->getscatterantialiased_cplot());
-  stringManager_->setValue(cplotpropertylegendtextitem_,
-                           Utilities::joinstring(curve->getlegendtext_cplot()));
   boolManager_->setValue(cplotpropertylegendvisibleitem_,
                          curve->getlegendvisible_cplot());
+  stringManager_->setValue(cplotpropertylegendtextitem_,
+                           Utilities::joinstring(curve->getlegendtext_cplot()));
 }
 
 void PropertyEditor::Bar2DPropertyBlock(Bar2D *bargraph, AxisRect2D *axisrect) {
@@ -7213,9 +7215,9 @@ void PropertyEditor::setObjectPropertyId() {
       "cplotpropertyscatterstrokestyleitem_");
   cplotpropertyscatterantialiaseditem_->setPropertyId(
       "cplotpropertyscatterantialiaseditem_");
-  cplotpropertylegendtextitem_->setPropertyId("cplotpropertylegendtextitem_");
   cplotpropertylegendvisibleitem_->setPropertyId(
       "cplotpropertylegendvisibleitem_");
+  cplotpropertylegendtextitem_->setPropertyId("cplotpropertylegendtextitem_");
 
   // Box Properties block
   barplotpropertyxaxisitem_->setPropertyId("barplotpropertyxaxisitem_");

--- a/alphaplot/src/core/widgets/propertyeditor.h
+++ b/alphaplot/src/core/widgets/propertyeditor.h
@@ -325,6 +325,7 @@ class PropertyEditor : public QDockWidget {
   QtProperty *lsplotpropertyscatterstrokethicknessitem_;
   QtProperty *lsplotpropertyscatterstrokestyleitem_;
   QtProperty *lsplotpropertyscatterantialiaseditem_;
+  QtProperty *lsplotpropertylegendvisibleitem_;
   QtProperty *lsplotpropertylegendtextitem_;
 
   // LineSpecialChannel Properties block

--- a/alphaplot/src/core/widgets/propertyeditor.h
+++ b/alphaplot/src/core/widgets/propertyeditor.h
@@ -251,6 +251,7 @@ class PropertyEditor : public QDockWidget {
   QtProperty *itempropertylegendoriginxitem_;
   QtProperty *itempropertylegendoriginyitem_;
   QtProperty *itempropertylegendvisibleitem_;
+  QtProperty *itempropertylegendmarginitem_;
   QtProperty *itempropertylegendfontitem_;
   QtProperty *itempropertylegendtextcoloritem_;
   QtProperty *itempropertylegendiconwidthitem_;

--- a/alphaplot/src/core/widgets/propertyeditor.h
+++ b/alphaplot/src/core/widgets/propertyeditor.h
@@ -379,6 +379,7 @@ class PropertyEditor : public QDockWidget {
   QtProperty *cplotpropertyscatterstrokestyleitem_;
   QtProperty *cplotpropertyscatterantialiaseditem_;
   QtProperty *cplotpropertylegendtextitem_;
+  QtProperty *cplotpropertylegendvisibleitem_;
 
   // Box Properties block
   QtProperty *barplotpropertyxaxisitem_;

--- a/alphaplot/src/core/widgets/propertyeditor.h
+++ b/alphaplot/src/core/widgets/propertyeditor.h
@@ -331,6 +331,7 @@ class PropertyEditor : public QDockWidget {
   // LineSpecialChannel Properties block
   QtProperty *channelplotpropertyxaxisitem_;
   QtProperty *channelplotpropertyyaxisitem_;
+  QtProperty *channelplotpropertylegendvisibleitem_;
   QtProperty *channelplotpropertylegendtextitem_;
   QtProperty *channel1plotpropertygroupitem_;
   QtProperty *channel1plotpropertylinestyleitem_;
@@ -444,6 +445,7 @@ class PropertyEditor : public QDockWidget {
   QtProperty *vectorpropertylineendingheightitem_;
   QtProperty *vectorpropertylineendingwidthitem_;
   QtProperty *vectorpropertylineantialiaseditem_;
+  QtProperty *vectorpropertylegendvisibleitem_;
   QtProperty *vectorpropertylegendtextitem_;
 
   // Pie Properties Block

--- a/alphaplot/src/core/widgets/propertyeditor.h
+++ b/alphaplot/src/core/widgets/propertyeditor.h
@@ -378,8 +378,8 @@ class PropertyEditor : public QDockWidget {
   QtProperty *cplotpropertyscatterstrokethicknessitem_;
   QtProperty *cplotpropertyscatterstrokestyleitem_;
   QtProperty *cplotpropertyscatterantialiaseditem_;
-  QtProperty *cplotpropertylegendtextitem_;
   QtProperty *cplotpropertylegendvisibleitem_;
+  QtProperty *cplotpropertylegendtextitem_;
 
   // Box Properties block
   QtProperty *barplotpropertyxaxisitem_;

--- a/alphaplot/src/core/widgets/propertyeditor.h
+++ b/alphaplot/src/core/widgets/propertyeditor.h
@@ -251,6 +251,7 @@ class PropertyEditor : public QDockWidget {
   QtProperty *itempropertylegendoriginxitem_;
   QtProperty *itempropertylegendoriginyitem_;
   QtProperty *itempropertylegendvisibleitem_;
+  QtProperty *itempropertylegenddirectionitem_;
   QtProperty *itempropertylegendmarginitem_;
   QtProperty *itempropertylegendfontitem_;
   QtProperty *itempropertylegendtextcoloritem_;


### PR DESCRIPTION
## All the changes

- [x] Add legend visible property in Curve2D, LineSpecial2D and Vector2D.
- [x] Add legend margins.
- [x] Add legend direction property ("Rows" or "Columns").
- [ ] Load legend title property 
> ~Before: the legend title and font were saved, but were not loaded later.~
> ~Now: the legend title and font are loaded, but only if the visible property is marked "True".~
> UPDATE: this was causing crash in xml opening, so it was removed.
- [x] Fix save/load text label rotation.
> Before: create a table with a Text Type, plot the graph, change the rotation of the labels  and save it. When the graph is loaded, the text label has been rotated to 45º.
> Now: the rotation of the Text Type labels can be loaded successfully.
- [ ] Add subscript and superscript in text and labels.
> It was not implemented in this PR but I would like to see this feature in the future.

## The new features

* The visible property allows to add or remove the plotted curve from the legend.

![fig1](https://user-images.githubusercontent.com/50991168/104079881-cea17780-5203-11eb-86c8-a069866c5344.jpg)

* You can now choose between "Rows" or "Columns" to change the direction of plotted items.

* Using the same property as "Text", the legend margins can be changed.

![fig2](https://user-images.githubusercontent.com/50991168/104079888-da8d3980-5203-11eb-976a-bfa98bdbae11.jpg)

* All of these features can be saved/loaded successfully.

![fig3](https://user-images.githubusercontent.com/50991168/104079906-f4c71780-5203-11eb-8be7-032b78817c3a.jpg)
